### PR TITLE
Refactor ProfileImage Component and Add Shape Optionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "pdf-cv",
+  "name": "pdf-generator",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pdf-cv",
+      "name": "pdf-generator",
       "version": "0.0.0",
       "dependencies": {
+        "clsx": "^2.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^5.0.1"
@@ -1844,6 +1845,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -5272,8 +5281,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "7.1.0",
@@ -5482,6 +5490,11 @@
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
+    },
+    "clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -5830,15 +5843,13 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react-refresh": {
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.5.tgz",
       "integrity": "sha512-D53FYKJa+fDmZMtriODxvhwrO+IOqrxoEo21gMA0sjHdU6dPVH4OhyFip9ypl8HOF5RV5KdTo+rBQLvnY2cO8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -6742,8 +6753,7 @@
     "react-icons": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
-      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
-      "requires": {}
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw=="
     },
     "react-refresh": {
       "version": "0.14.0",
@@ -7023,8 +7033,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
       "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "tslib": {
       "version": "2.6.2",
@@ -7195,8 +7204,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
       "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "pdf": "tsx pdf.ts"
   },
   "dependencies": {
+    "clsx": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1"

--- a/src/components/Profile/Profile.css
+++ b/src/components/Profile/Profile.css
@@ -11,12 +11,6 @@
   font-size: 14px;
 }
 
-.profile__header__image img {
-  height: 150px;
-  border-radius: 50%;
-  overflow: hidden;
-}
-
 .profile__header__lines {
   display: flex;
   flex-direction: column;

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -48,7 +48,7 @@ const ProfileHeader = ({
         {lines.map((line, index) => (
           <p key={index}>{line}</p>
         ))}
-      P</div>
+      </div>
       <div className="profile__header__links">
         <div className="profile__header__link">
           <FaGithub />

--- a/src/components/Profile/Profile.tsx
+++ b/src/components/Profile/Profile.tsx
@@ -2,8 +2,8 @@ import "./Profile.css";
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 import { FaSquareXTwitter } from "react-icons/fa6";
 import Title from "../Title/Title";
-import ProfilePicture from "../../assets/profile.png";
 import Bubble from "../Bubble/Bubble";
+import ProfileImage from "./ProfileImage/ProfileImage";
 
 type TechnicalCategory = {
   category: string;
@@ -43,14 +43,12 @@ const ProfileHeader = ({
 }: Data["profile"]) => {
   return (
     <div className="profile__header">
-      <div className="profile__header__image">
-        <img src={ProfilePicture} alt="Profile" />
-      </div>
+      <ProfileImage circular={true}/>
       <div className="profile__header__lines">
         {lines.map((line, index) => (
           <p key={index}>{line}</p>
         ))}
-      </div>
+      P</div>
       <div className="profile__header__links">
         <div className="profile__header__link">
           <FaGithub />

--- a/src/components/Profile/ProfileImage/ProfileImage.css
+++ b/src/components/Profile/ProfileImage/ProfileImage.css
@@ -1,0 +1,8 @@
+.profile__header__image img {
+  height: 150px;
+  overflow: hidden;
+}
+
+.profile__header__image__circular img {
+  border-radius: 50%;
+}

--- a/src/components/Profile/ProfileImage/ProfileImage.css
+++ b/src/components/Profile/ProfileImage/ProfileImage.css
@@ -4,5 +4,5 @@
 }
 
 .profile__header__image__circular img {
-  border-radius: 50%;
+  border-radius: 9999px;
 }

--- a/src/components/Profile/ProfileImage/ProfileImage.tsx
+++ b/src/components/Profile/ProfileImage/ProfileImage.tsx
@@ -1,14 +1,16 @@
 import "./ProfileImage.css";
 import ProfilePicture from "../../../assets/profile.png";
+import clsx from 'clsx';
 
 type ImageOptions = {
   circular?: boolean;
 };
 
 const ProfileImage = (options: ImageOptions = {}) => {
-  const classes = `profile__header__image ${
-    options.circular ? "profile__header__image__circular" : ""
-  }`;
+  const classes = clsx(
+    'profile__header__image',
+    { 'profile__header__image__circular': options.circular }
+  );
 
   return (
     <div className={classes}>

--- a/src/components/Profile/ProfileImage/ProfileImage.tsx
+++ b/src/components/Profile/ProfileImage/ProfileImage.tsx
@@ -1,0 +1,20 @@
+import "./ProfileImage.css";
+import ProfilePicture from "../../../assets/profile.png";
+
+type ImageOptions = {
+  circular?: boolean;
+};
+
+const ProfileImage = (options: ImageOptions = {}) => {
+  const classes = `profile__header__image ${
+    options.circular ? "profile__header__image__circular" : ""
+  }`;
+
+  return (
+    <div className={classes}>
+      <img src={ProfilePicture} alt="Profile" />
+    </div>
+  );
+};
+
+export default ProfileImage;


### PR DESCRIPTION
This PR encapsulates the profile image within its own component. Additionally, it adds an option to render the image in a square shape. By default, the image will be displayed in a square format when using the component. However, I enabled the circular option in the profile component to not change the previous view. The user can simply delete the option circular=true in order to have the squared image.