### PR TITLE
feat: run vite server on pdf generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ The CV PDF Generator is a React app used to build a CV and export it as a PDF.
 
 ```sh
 npm install
-# Starts the vite server
-npm run dev
-# Generate the pdf
+
 npm run pdf
+```
+
+## Development / Debug
+
+If you want to tweak your CV or debug some features you are implementing, you can run the dev server using:
+
+```sh
+npm run dev
 ```
 
 ## Built With

--- a/pdf.ts
+++ b/pdf.ts
@@ -1,12 +1,27 @@
 import puppeteer from "puppeteer";
 import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createServer } from "vite";
 
 (async () => {
+  const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+  console.log("⏳ Starting Vite server");
+  const server = await createServer({
+    configFile: "vite.config.ts",
+    root: __dirname,
+  });
+  await server.listen();
+
+  console.log("🐾 Opening Puppeteer");
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
 
-  await page.goto("http://localhost:5173/", { waitUntil: "networkidle0" });
+  await page.goto(server.resolvedUrls?.local[0] as string, {
+    waitUntil: "networkidle0",
+  });
 
+  console.log("🖨️  Generating PDF");
   const pdf = await page.pdf({
     format: "A4",
     margin: { top: 0, bottom: 0, left: 0, right: 0 },
@@ -14,7 +29,11 @@ import { writeFileSync } from "node:fs";
     scale: 0.8,
   });
 
+  console.log("💾 Saving PDF");
   writeFileSync("output.pdf", pdf);
 
   await browser.close();
+
+  await server.close();
+  console.log("🏁 Done");
 })();


### PR DESCRIPTION
Currently we need to manually run the Vite server before generating the PDF which can be confusing.
Using the [`createServer` API ](https://vitejs.dev/guide/api-javascript#createserver)we can start a server on demand when we generate a PDF.