### PR TITLE
feat: header data input changed to array string

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import Profile from "./components/Profile/Profile";
 function App() {
   return (
     <div className="app__container">
-      <Header headerData={data.header} />
+      <Header name={data.header.name} resume={data.header.resume} />
       <div className="app__body">
         <div
           className="app__body-left"

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,17 +3,16 @@ import "./Header.css";
 
 type HeaderProps = {
   name: string;
-  resume: string;
+  resume: string[];
 };
 
-const Header = ({ headerData }: { headerData: HeaderProps }) => {
-  const resumeLines = headerData.resume.split("\n");
+const Header = ({ name, resume }: HeaderProps) => {
   return (
     <>
       <div className="header__container">
-        <h1 className="header__name">{headerData.name}</h1>
+        <h1 className="header__name">{name}</h1>
         <div className="header__lines">
-          {resumeLines.map((line, index) => (
+          {resume.map((line, index) => (
             <p key={index}>{line}</p>
           ))}
         </div>

--- a/src/data.json
+++ b/src/data.json
@@ -1,8 +1,13 @@
 {
   "header": {
     "name": "Lorem Ipsum",
-    "resume": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. \nVestibulum rutrum mi quis tellus ullamcorper, nec tempus nulla\nFusce velit urna, euismod ut nibh ut, finibus vestibulum magna."
+    "resume": [
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      "Vestibulum rutrum mi quis tellus ullamcorper, nec tempus nulla",
+      "Fusce velit urna, euismod ut nibh ut, finibus vestibulum magna."
+    ]
   },
+
   "workExperience": [
     {
       "position": "Full Stack Software Lopsum",
@@ -116,7 +121,8 @@
         {
           "text": "Phasellus eu sollicitudin nisi. Vivamus ullamcorper facilisis risus, sed hendrerit lacus scelerisque vel.",
           "bulletPoint": true
-        },        {
+        },
+        {
           "text": "Fusce lobortis eros suscipit, viverra lacus in, ullamcorper purus.",
           "bulletPoint": true
         }
@@ -142,7 +148,8 @@
         {
           "text": "Phasellus eu sollicitudin nisi. Vivamus ullamcorper facilisis risus, sed hendrerit lacus scelerisque vel.",
           "bulletPoint": true
-        },        {
+        },
+        {
           "text": "Fusce lobortis eros suscipit, viverra lacus in, ullamcorper purus.",
           "bulletPoint": true
         }


### PR DESCRIPTION
Addresses: Implement a more reliable data input header.resume to string arrays instead of one long string  https://github.com/alcpereira/pdf-generator/issues/3


Updated data.json header.resume data input type from string to string array
edited code on header.tsx to implement data input changes