### PR TITLE
Make icons in ProfileLink clickable

### DIFF
--- a/src/components/Profile/ProfileLink/ProfileLink.css
+++ b/src/components/Profile/ProfileLink/ProfileLink.css
@@ -1,15 +1,15 @@
 .profile__header__link {
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
   padding: 0.125em;
+
+  a {
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
 
   span {
     font-size: 14px;
   }
-}
-
-.profile__header__link a {
-  text-decoration: none;
-  color: inherit;
 }

--- a/src/components/Profile/ProfileLink/ProfileLink.tsx
+++ b/src/components/Profile/ProfileLink/ProfileLink.tsx
@@ -29,8 +29,10 @@ const ProfileLink = ({ type, link }: ProfileLinkProps) => {
 
   return (
     <div className="profile__header__link">
-      {icon}
-      <a href={`https://${link}`}>{type}</a>
+      <a href={`https://${link}`} target="_blank" rel="noopener noreferrer">
+        {icon}
+        <span>{type}</span>
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
- Added `target="_blank"` and `rel="noopener noreferrer"` to `<a>` properties:This ensures that external links open in a new tab and helps avoid security risks by preventing the new page from gaining access to the referring page's context.

- Refactored CSS for cleaner structure:Removed redundant display: flex and `align-items: center` from `.profile__header__link` as the alignment is now handled within the `<a>` tag. 
- Made icons in ProfileLink clickable: Icons are now wrapped within the `<a>` tag, making them clickable along with the text.